### PR TITLE
Ensure Windows 11 readiness check exits with failure code

### DIFF
--- a/Check-InplaceUpgradeReadiness.ps1
+++ b/Check-InplaceUpgradeReadiness.ps1
@@ -1276,7 +1276,7 @@ if ($osCheck.PSObject.Properties['IsWindows11'] -and $osCheck.IsWindows11) {
     Write-Host "Device age estimate: $ageDetail" -ForegroundColor Cyan
   }
 
-  exit 0
+  exit 1
 }
 
 $cpuResult = Test-CPU


### PR DESCRIPTION
## Summary
- ensure the Windows 11 detection shortcut exits with status code 1 so all paths return the expected non-zero code

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d4594a1b78832a8476f11a1b1940d7